### PR TITLE
call_ref: add missing min() description.

### DIFF
--- a/Python Call reference/Python Call reference.md
+++ b/Python Call reference/Python Call reference.md
@@ -395,6 +395,7 @@ min(iterable, *[, key, default])
 ```py
 min(arg1, arg2, *args[, key])
 ```
+Return the smallest item in an iterable or the smallest of two or more arguments.
 
 
 ## 2.23. `oct()`


### PR DESCRIPTION
As per https://docs.python.org/3/library/functions.html#min